### PR TITLE
stop enforcing topretty

### DIFF
--- a/src/apod.rs
+++ b/src/apod.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 
 use crate::key;
-use crate::pretty::*;
+use crate::response::*;
 
 /// Base Client for ApodClient api
 #[derive(Debug, PartialEq)]
@@ -25,7 +25,7 @@ impl ApodClient {
     }
 
     /// Query function
-    pub fn query(&self) -> Result<String, Box<dyn Error>> {
+    pub fn query(&self) -> Result<Response, Box<dyn Error>> {
         let key: String = key::from_dotenv()?;
 
         if self.date.is_none() {
@@ -34,7 +34,7 @@ impl ApodClient {
             println!("Url: {}", url);
 
             let res: String = ureq::get(&url).call()?.into_string()?;
-            let apod = to_string_pretty(res).unwrap();
+            let apod: Response = into_response(res.as_str())?;
 
             Ok(apod)
         } else {
@@ -42,7 +42,7 @@ impl ApodClient {
             let url = format!("{}date={}&api_key={}", self.base_url, date, key);
 
             let res: String = ureq::get(&url).call()?.into_string()?;
-            let apod = to_string_pretty(res).unwrap();
+            let apod: Response = into_response(res.as_str())?;
 
             Ok(apod)
         }

--- a/src/donki.rs
+++ b/src/donki.rs
@@ -2,6 +2,7 @@ use std::error::Error;
 
 use crate::key;
 use crate::pretty::*;
+use crate::response::*;
 
 /// Base Client for Solar Flare API
 #[derive(Debug, PartialEq)]
@@ -18,14 +19,14 @@ impl SolarFlare {
     }
 
     /// Query method
-    pub fn query(&self, start: String, end: String) -> Result<String, Box<dyn Error>> {
+    pub fn query(&self, start: String, end: String) -> Result<Response, Box<dyn Error>> {
         let key: String = key::from_dotenv()?;
 
         let url: String = format!("{}{}&endDate={}&api_key={}", self.base_url, start, end, key);
         println!("Starting solar query from {}, to {}.", start, end);
 
         let res: String = ureq::get(&url).call()?.into_string()?;
-        let solar = to_string_pretty(res).unwrap();
+        let solar: Response = into_response(res.as_str()).unwrap();
 
         Ok(solar)
     }
@@ -46,14 +47,14 @@ impl GeoMagnetic {
     }
 
     /// Query method
-    pub fn query(&self, start: String, end: String) -> Result<String, Box<dyn Error>> {
+    pub fn query(&self, start: String, end: String) -> Result<Response, Box<dyn Error>> {
         let key: String = key::from_dotenv()?;
 
         let url: String = format!("{}{}&endDate={}&api_key={}", self.base_url, start, end, key);
         println!("Starting GeoMagnetic query from {}, to {}.", start, end);
 
         let res: String = ureq::get(&url).call()?.into_string()?;
-        let mag = to_string_pretty(res).unwrap();
+        let mag = into_response(res.as_str()).unwrap();
 
         Ok(mag)
     }

--- a/src/insight.rs
+++ b/src/insight.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 
 use crate::key;
-use crate::pretty::*;
+use crate::response::*;
 
 #[derive(Debug, PartialEq)]
 pub struct InsightWeather {
@@ -15,14 +15,14 @@ impl InsightWeather {
         }
     }
 
-    pub fn query(&self) -> Result<String, Box<dyn Error>> {
+    pub fn query(&self) -> Result<Response, Box<dyn Error>> {
         let key = key::from_dotenv()?;
 
         let url = format!("{}{}&feedtype=json&ver=1.0", self.base_url, key);
         println!("Starting Inisght Weather query: {}", url);
 
         let res: String = ureq::get(&url).call()?.into_string()?;
-        let mrover = to_string_pretty(res).unwrap();
+        let mrover = into_response(res.as_str()).unwrap();
 
         Ok(mrover)
     }

--- a/src/jpl.rs
+++ b/src/jpl.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 
-use crate::pretty::*;
+use crate::response::*;
 
 /// Atmospheric Impact Data
 #[derive(Debug, PartialEq)]
@@ -21,12 +21,12 @@ impl FireballClient {
         self.limit = Some(limit)
     }
 
-    pub fn query(&self) -> Result<String, Box<dyn Error>> {
+    pub fn query(&self) -> Result<Response, Box<dyn Error>> {
         if self.limit.is_none() {
             let url = format!("{}", self.base_url);
 
             let res: String = ureq::get(&url).call()?.into_string()?;
-            let fireball = to_string_pretty(res).unwrap();
+            let fireball = into_response(res.as_str()).unwrap();
             Ok(fireball)
         } else {
             let limit = self.limit.as_ref().unwrap();
@@ -34,7 +34,7 @@ impl FireballClient {
             let url = format!("{}?limit={}", self.base_url, limit);
 
             let res: String = ureq::get(&url).call()?.into_string()?;
-            let fireball = to_string_pretty(res).unwrap();
+            let fireball = into_response(res.as_str()).unwrap();
 
             Ok(fireball)
         }
@@ -76,14 +76,14 @@ impl MissionDesign {
     }
 
     /// Mission Design: Q mode (query)
-    pub fn query(&self, query_type: QueryType, query: &str) -> Result<String, Box<dyn Error>> {
+    pub fn query(&self, query_type: QueryType, query: &str) -> Result<Response, Box<dyn Error>> {
         // Default Query Mode
         match query_type {
             QueryType::DES => {
                 let url = format!("{}des={}", self.base_url, query);
 
                 let res: String = ureq::get(&url).call()?.into_string()?;
-                let mission = to_string_pretty(res).unwrap();
+                let mission = into_response(res.as_str()).unwrap();
 
                 Ok(mission)
             }
@@ -91,7 +91,7 @@ impl MissionDesign {
                 let url = format!("{}sstr={}", self.base_url, query);
 
                 let res: String = ureq::get(&url).call()?.into_string()?;
-                let mission = to_string_pretty(res).unwrap();
+                let mission = into_response(res.as_str()).unwrap();
 
                 Ok(mission)
             }
@@ -155,7 +155,7 @@ impl MissionDesignAccessible {
     }
 
     /// Must set Limit, Crit, and year values
-    pub fn lim_crit_year(&self) -> Result<String, Box<dyn Error>> {
+    pub fn lim_crit_year(&self) -> Result<Response, Box<dyn Error>> {
         assert!(self.limit != None, "Limit is None");
         assert!(self.crit != None, "Crit is None");
         assert!(self.year != None, "Year is None");
@@ -169,7 +169,7 @@ impl MissionDesignAccessible {
         );
 
         let res = ureq::get(&url).call()?.into_string()?;
-        let pretty = to_string_pretty(res).unwrap();
+        let pretty = into_response(res.as_str()).unwrap();
 
         Ok(pretty)
     }
@@ -235,7 +235,7 @@ impl MissionDesignMap {
         self.step = Some(step)
     }
 
-    pub fn query(&self) -> Result<String, Box<dyn Error>> {
+    pub fn query(&self) -> Result<Response, Box<dyn Error>> {
         assert!(self.des != None, "Des is None");
         assert!(self.mjd0 != None, "Mjd0 is None");
         assert!(self.span != None, "Span is None");
@@ -257,7 +257,7 @@ impl MissionDesignMap {
         println!("Url: {}", url);
 
         let res: String = ureq::get(&url).call()?.into_string()?;
-        let map = to_string_pretty(res).unwrap();
+        let map = into_response(res.as_str()).unwrap();
 
         Ok(map)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,8 @@ pub mod neo;
 pub mod insight;
 
 
+pub mod response;
+
 /// For interacting with the Tech Transfer API. Defaults to the patent collection but can 
 /// also be switched to patent protected, software, or spinoff via the .switch() method.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,23 @@ pub mod neo;
 pub mod insight;
 
 
+/// Methods for manipulating responses. Get serde_json dumps or byte vectors from responses.
+/// # Example
+/// ```
+/// use voyager_client::donki::*;
+/// use serde_json::Value as JsonValue;
+///
+/// // Setup range
+/// let start = String::from("2019-01-01");
+/// let end = String::from("2022-01-01");
+/// // Instantiate base
+/// let base = GeoMagnetic::new();
+/// // Try query
+/// let res = base.query(start, end).unwrap();
+/// // Handle Response
+/// let json: JsonValue = res.json().unwrap();
+/// let bytes_vec: Vec<u8> = res.bytedump().unwrap();
+/// ```
 pub mod response;
 
 /// For interacting with the Tech Transfer API. Defaults to the patent collection but can 

--- a/src/neo.rs
+++ b/src/neo.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 
 use crate::key;
-use crate::pretty::*;
+use crate::response::*;
 
 #[derive(Debug)]
 pub struct Neo {
@@ -15,14 +15,14 @@ impl Neo {
         }
     }
 
-    pub fn query(&self, start: String, end: String) -> Result<String, Box<dyn Error>> {
+    pub fn query(&self, start: String, end: String) -> Result<Response, Box<dyn Error>> {
         let key: String = key::from_dotenv()?;
 
         let url: String = format!("{}{}&endDate={}&api_key={}", self.base_url, start, end, key);
         println!("Starting Neo query from {}, to {}.", start, end);
 
         let res: String = ureq::get(&url).call()?.into_string()?;
-        let neo = to_string_pretty(res).unwrap();
+        let neo = into_response(res.as_str()).unwrap();
 
         Ok(neo)
     }

--- a/src/response.rs
+++ b/src/response.rs
@@ -2,7 +2,6 @@ use serde_json::Value as JsonValue;
 use serde_derive::{Serialize, Deserialize};
 use std::error::Error;
 
-
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Response {
     json: JsonValue,
@@ -13,9 +12,14 @@ impl Response {
         Response { json }
     }
 
-    pub fn bytedump(&mut self) -> Result<Vec<u8>, Box<dyn Error>> {
+    pub fn bytedump(&self) -> Result<Vec<u8>, Box<dyn Error>> {
         let bytes: Vec<u8> = serde_json::to_vec(&self.json)?;
         Ok(bytes)
+    }
+
+    pub fn json(&self) -> Result<JsonValue, Box<dyn Error>> {
+        let dump = self.json.clone();
+        Ok(dump)
     }
 }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,0 +1,27 @@
+use serde_json::Value as JsonValue;
+use serde_derive::{Serialize, Deserialize};
+use std::error::Error;
+
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Response {
+    json: JsonValue,
+}
+
+impl Response {
+    pub fn new(json: JsonValue) -> Self {
+        Response { json }
+    }
+
+    pub fn bytedump(&mut self) -> Result<Vec<u8>, Box<dyn Error>> {
+        let bytes: Vec<u8> = serde_json::to_vec(&self.json)?;
+        Ok(bytes)
+    }
+}
+
+/// Handles responses
+pub fn into_response(res: &str) -> Result<Response, Box<dyn Error>> {
+    let json: JsonValue = serde_json::from_str(res)?;
+
+    Ok(Response::new(json))
+}

--- a/src/response.rs
+++ b/src/response.rs
@@ -21,6 +21,12 @@ impl Response {
         let dump = self.json.clone();
         Ok(dump)
     }
+
+    pub fn to_pretty(&self) -> Result<String, Box<dyn Error>> {
+        let json = self.json.clone();
+        let pretty = serde_json::to_string_pretty(&json)?;
+        Ok(pretty)
+    }
 }
 
 /// Handles responses

--- a/src/tech.rs
+++ b/src/tech.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 
 use crate::key;
-use crate::pretty::*;
+use crate::response::*;
 
 pub enum Collections {
     Patent,
@@ -45,18 +45,14 @@ impl TechTransferClient {
         }
     }
 
-    pub fn query(&self, query: String) -> Result<String, Box<dyn Error>> {
+    pub fn query(&self, query: String) -> Result<Response, Box<dyn Error>> {
         let key: String = key::from_dotenv()?;
 
         let url = format!("{}{}&api_key={}", self.base_url, query, key);
 
         let res: String = ureq::get(&url).call()?.into_string()?;
-        let tech = to_string_pretty(res);
+        let tech = into_response(res.as_str()).unwrap();
 
-        if tech.is_ok() {
-            Ok(tech.unwrap())
-        } else {
-            Err(tech.unwrap_err())
-        }
+        Ok(tech)
     }
 }

--- a/tests/unit_test.rs
+++ b/tests/unit_test.rs
@@ -18,13 +18,18 @@ mod test {
     #[test]
     fn try_apod() {
         use voyager_client::apod;
+        use voyager_client::response::*;
 
         // Instantiate base
         let mut base = apod::ApodClient::new();
         // Try to set the date for query
         base.set_date(String::from("2021-06-07"));
         // Try query
-        base.query().unwrap();
+        let mut res: Response = base.query().unwrap();
+        println!("{:?}", res);
+
+        let bytes_vec = res.bytedump();
+        println!("{:?}", bytes_vec)
     }
 
     #[test]

--- a/tests/unit_test.rs
+++ b/tests/unit_test.rs
@@ -25,11 +25,10 @@ mod test {
         // Try to set the date for query
         base.set_date(String::from("2021-06-07"));
         // Try query
-        let mut res: Response = base.query().unwrap();
-        println!("{:?}", res);
+        let res: Response = base.query().unwrap();
 
-        let bytes_vec = res.bytedump();
-        println!("{:?}", bytes_vec)
+        let json = res.json();
+        println!("{}", json.unwrap());
     }
 
     #[test]

--- a/tests/unit_test.rs
+++ b/tests/unit_test.rs
@@ -26,9 +26,7 @@ mod test {
         base.set_date(String::from("2021-06-07"));
         // Try query
         let res: Response = base.query().unwrap();
-
-        let json = res.json();
-        println!("{}", json.unwrap());
+        println!("{}", res.to_pretty().unwrap());
     }
 
     #[test]


### PR DESCRIPTION
This merge indicates that to_pretty is no longer being enforced on base clients responses from their query methods. Adds a new struct "Response" which holds implementations for manipulating responses, such as a json method to grab the serde_json::Value object representation of the response, bytedump method to get a Vector of bytes representing the response, and a to_pretty method to turn the json into a pretty string.